### PR TITLE
Check for operation parameters first before iterating

### DIFF
--- a/src/createClient.js
+++ b/src/createClient.js
@@ -102,9 +102,11 @@ function processSchema(schema){
       apiObject.operations.forEach(function(operation){
         operation.apiObject = apiObject;
 
-        operation.parameters.forEach(function(parameter){
-          parameter.operation = operation;
-        });
+        if (operation.parameters) {
+          operation.parameters.forEach(function(parameter){
+            parameter.operation = operation;
+          });
+        }
       });
     });
   });


### PR DESCRIPTION
I'm using this downstream via _swagger-angular-client_. This is breaking my app when I try to use it for get requests that don't have any parameters.
